### PR TITLE
Add basic ingredients for CONDA/cl.exe build for Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,13 @@ if ( MCPL_ENABLE_CPACK )
   include(CPack)
 endif()
 
+set(MCPL_CONDA_LIB "")
+set(MCPL_CONDA_INCLUDE "") 
+if ( MCPL_CONDA_WINDOWS )
+  set(MCPL_CONDA_LIB "$ENV{CONDA_PREFIX}/Library/lib")
+  set(MCPL_CONDA_INCLUDE "$ENV{CONDA_PREFIX}/Library/include")
+endif()
+
 if( NOT MCPL_NOTOUCH_CMAKE_BUILD_TYPE )
   if ( NOT gen_is_multicfg )
     if ( "x${CMAKE_BUILD_TYPE}" STREQUAL "x" )
@@ -217,7 +224,8 @@ add_zlib_dependency( mcpl -DMCPL_HASZLIB )
 
 target_include_directories(mcpl
  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/mcpl>
-        $<INSTALL_INTERFACE:${MCPL_INCDIR}> )
+        $<INSTALL_INTERFACE:${MCPL_INCDIR}>
+		${MCPL_CONDA_INCLUDE} )
 
 if (MATH_NEEDS_LIBM)
   target_link_libraries( mcpl PRIVATE m )
@@ -232,6 +240,10 @@ endif()
 install( TARGETS mcpl mcpltool EXPORT MCPLTargets ${INSTDEST} )
 install( EXPORT MCPLTargets FILE MCPLTargets.cmake NAMESPACE MCPL:: DESTINATION ${MCPL_CMAKEDIR} )
 add_library(MCPL::mcpl ALIAS mcpl)#always alias namespaces locally
+
+if ( MCPL_CONDA_WINDOWS )
+	install( FILES "util/mcpl-config.bat" DESTINATION ${MCPL_BINDIR} )
+endif()
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file( "${PROJECT_BINARY_DIR}/MCPLConfigVersion.cmake"

--- a/src/mcpl/mcpl.c
+++ b/src/mcpl/mcpl.c
@@ -106,7 +106,13 @@
 #include <string.h>
 #include <assert.h>
 #include <math.h>
+// On non-cl.exe compiler, use normal <unistd.h> ... 
+// otherwise use local wrapper to MS-provided headers.
+#ifndef _MSC_EXTENSIONS
 #include <unistd.h>
+#else
+#include "win-unistd.h"
+#endif
 #include <limits.h>
 #ifdef MCPL_THIS_IS_MS
 #  include <fcntl.h>

--- a/src/mcpl/win-unistd.h
+++ b/src/mcpl/win-unistd.h
@@ -1,0 +1,58 @@
+#ifndef _UNISTD_H
+#define _UNISTD_H    1
+
+/* This is intended as a drop-in replacement for unistd.h on Windows.
+ * Please add functionality as needed.
+ * https://stackoverflow.com/a/826027/1202830
+ */
+
+#include <stdlib.h>
+#include <io.h>
+// TODO: In case of cl.exe on Windows, set compile-time include to pick
+// up path to conda-provided getopt.h!
+#include "c:/install_mcstas/miniconda3/Library/include/getopt.h"
+#include <process.h> /* for getpid() and the exec..() family */
+#include <direct.h> /* for _getcwd() and _chdir() */
+
+#define srandom srand
+#define random rand
+
+/* Values for the second argument to access.
+   These may be OR'd together.  */
+#define R_OK    4       /* Test for read permission.  */
+#define W_OK    2       /* Test for write permission.  */
+//#define   X_OK    1       /* execute permission - unsupported in windows*/
+#define F_OK    0       /* Test for existence.  */
+
+#define access _access
+#define dup2 _dup2
+#define execve _execve
+#define ftruncate _chsize
+#define unlink _unlink
+#define fileno _fileno
+#define getcwd _getcwd
+#define chdir _chdir
+#define isatty _isatty
+#define lseek _lseek
+/* read, write, and close are NOT being #defined here, because while there are file handle specific versions for Windows, they probably don't work for sockets. You need to look at your app and consider whether to call e.g. closesocket(). */
+
+#ifdef _WIN64
+#define ssize_t __int64
+#else
+#define ssize_t long
+#endif
+
+#define STDIN_FILENO 0
+#define STDOUT_FILENO 1
+#define STDERR_FILENO 2
+/* should be in some equivalent to <sys/types.h> */
+typedef __int8            int8_t;
+typedef __int16           int16_t; 
+typedef __int32           int32_t;
+typedef __int64           int64_t;
+typedef unsigned __int8   uint8_t;
+typedef unsigned __int16  uint16_t;
+typedef unsigned __int32  uint32_t;
+typedef unsigned __int64  uint64_t;
+
+#endif /* unistd.h  */

--- a/src/mcpl/win-unistd.h
+++ b/src/mcpl/win-unistd.h
@@ -10,7 +10,7 @@
 #include <io.h>
 // TODO: In case of cl.exe on Windows, set compile-time include to pick
 // up path to conda-provided getopt.h!
-#include "c:/install_mcstas/miniconda3/Library/include/getopt.h"
+#include <getopt.h>
 #include <process.h> /* for getpid() and the exec..() family */
 #include <direct.h> /* for _getcwd() and _chdir() */
 

--- a/util/mcpl-config.bat
+++ b/util/mcpl-config.bat
@@ -1,0 +1,1 @@
+@python %CONDA_PREFIX%/bin/mcpl-config %*


### PR DESCRIPTION
This PR includes
* Minimal edits to `src/mcpl/mcpl.c` for missing windows unistd/getopt
* A public domain (?) implementation of `unistd.h` in `src/mcpl` (was taken from https://stackoverflow.com/a/826027/1202830 - author gives no explicit license there)
* `CMAKE` infrastructure to ensure the `CONDA` include path is explicitly set for `cl.exe` to pick up
* In `util/` I have put a .bat snippet to enable `python` from the surrounding `conda` env being run on the `bin/mcpl-config` python script 
* `zlib` is successfully picked up from `CONDA` via the above include-workaround

Once this is in place, we should be ready to build a Windows package with enough features for a functional McStas release on Windows / conda via a build.bat with something like

```
cmake -DCMAKE_INSTALL_PREFIX=%PREFIX%  ^
-S %SRCDIR% -G "NMake Makefiles"  ^
-DBUILD_SHARED_LIBS=ON -DMCPL_DISABLE_CXX=ON ^
-DMCPL_NOTOUCH_CMAKE_BUILD_TYPE=ON  ^
-DMCPL_ENABLE_RPATHMOD=OFF  ^
-DCMAKE_INSTALL_LIBDIR=lib - ^
DCMAKE_BUILD_TYPE=Release ^
-DMCPL_ENABLE_EXAMPLES=OFF  ^
-DMCPL_ENABLE_PYTHON=OFF  ^
-DMCPL_ENABLE_ZLIB=USEPREINSTALLED  ^
-DMCPL_CONDA_WINDOWS=ON  ^
-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON  ^
%CMAKE_ARGS%

cmake --build . --target install --config Release
```

(- Hinges on conda dependencies `getopt-win32`, `zlib` etc.)