### PR TITLE
Add utility functions for creating and merging MCPL files in MPI scenarios

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
 v2.1.1 (work in progress)
+      * Add mcpl_create_outfile_mpi and mcpl_merge_outfiles_mpi utility
+        functions, to handle some of the tedium needed for applications creating
+        multiple MCPL files from a number of MPI processes before finally
+        merging to a single file.
       * ...
 
 v2.1.0 2024-05-17

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,11 @@
 v2.1.1 (work in progress)
-      * Add mcpl_create_outfile_mpi and mcpl_merge_outfiles_mpi utility
+      * Add mcpl_create_outfile_mpi and mcpl_merge_outfiles_mpi utility C
         functions, to handle some of the tedium needed for applications creating
         multiple MCPL files from a number of MPI processes before finally
         merging to a single file.
+      * Add mcpl_name_helper utility C function for easily parsing user input
+        strings into absolute or relative path names to a corresponding MCPL
+        file, with or without a .mcpl or .mcpl.gz suffix.
       * ...
 
 v2.1.0 2024-05-17

--- a/mcpl_core/include/mcpl.h.in
+++ b/mcpl_core/include/mcpl.h.in
@@ -418,8 +418,9 @@ extern "C" {
   /* The intermediate files will be named like filename, except with the       */
   /* extension ".worker%i.mcpl[.gz]", and it is the responsibility of the      */
   /* calling code to ensure that no such files might already be                */
-  /* existing. During normal operations, the intermediate files will be        */
-  /* removed again by the call to mcpl_merge_outfiles_mpi.                     */
+  /* existing, and to close them with mcpl_closeandgzip_outfile. During normal */
+  /* operations, the intermediate files will be removed again by the call to   */
+  /* mcpl_merge_outfiles_mpi. Using nproc=1 is allowed as a special case.      */
 
   MCPL_API mcpl_outfile_t mcpl_create_outfile_mpi( const char * filename,
                                                    unsigned iproc,

--- a/mcpl_core/include/mcpl.h.in
+++ b/mcpl_core/include/mcpl.h.in
@@ -422,11 +422,11 @@ extern "C" {
   /* operations, the intermediate files will be removed again by the call to   */
   /* mcpl_merge_outfiles_mpi. Using nproc=1 is allowed as a special case.      */
   MCPL_API mcpl_outfile_t mcpl_create_outfile_mpi( const char * filename,
-                                                   unsigned iproc,
-                                                   unsigned nproc );
+                                                   unsigned long iproc,
+                                                   unsigned long nproc );
 
   MCPL_API void mcpl_merge_outfiles_mpi( const char * filename,
-                                         unsigned nproc );
+                                         unsigned long nproc );
 
   /* Utility for estimating the output name of a given filename, and can       */
   /* accept either relative or absolute filenames with or without .mcpl or     */

--- a/mcpl_core/include/mcpl.h.in
+++ b/mcpl_core/include/mcpl.h.in
@@ -409,6 +409,26 @@ extern "C" {
   MCPL_API int mcpl_wrap_wmain( int argc, wchar_t** argv, int(*)(int,char**) );
 #endif
 
+  /* Utilities for MPI output where each worker creates its own file, followed */
+  /* by a final merging into one file. The filename should be the final        */
+  /* desired output name (optionally ending in .mcpl or .mcpl.gz), nproc the   */
+  /* total number of files, and iproc the index from 0 to nproc-1 of the       */
+  /* worker process opening the file.                                          */
+  /*                                                                           */
+  /* The intermediate files will be named like filename, except with the       */
+  /* extension ".worker%i.mcpl[.gz]", and it is the responsibility of the      */
+  /* calling code to ensure that no such files might already be                */
+  /* existing. During normal operations, the intermediate files will be        */
+  /* removed again by the call to mcpl_merge_outfiles_mpi.                     */
+
+  MCPL_API mcpl_outfile_t mcpl_create_outfile_mpi( const char * filename,
+                                                   unsigned iproc,
+                                                   unsigned nproc );
+  MCPL_API void mcpl_merge_outfiles_mpi( const char * filename,
+                                         unsigned nproc );
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/mcpl_core/include/mcpl.h.in
+++ b/mcpl_core/include/mcpl.h.in
@@ -421,13 +421,26 @@ extern "C" {
   /* existing, and to close them with mcpl_closeandgzip_outfile. During normal */
   /* operations, the intermediate files will be removed again by the call to   */
   /* mcpl_merge_outfiles_mpi. Using nproc=1 is allowed as a special case.      */
-
   MCPL_API mcpl_outfile_t mcpl_create_outfile_mpi( const char * filename,
                                                    unsigned iproc,
                                                    unsigned nproc );
+
   MCPL_API void mcpl_merge_outfiles_mpi( const char * filename,
                                          unsigned nproc );
 
+  /* Utility for estimating the output name of a given filename, and can       */
+  /* accept either relative or absolute filenames with or without .mcpl or     */
+  /* .mcpl.gz suffixes. The mode parameter controls the string returned:       */
+  /*                                                                           */
+  /*   mode "M" : /abs/path/base.mcpl                                          */
+  /*   mode "G" : /abs/path/base.mcpl.gz                                       */
+  /*   mode "B" : /abs/path/base                                               */
+  /*   mode "m" : base.mcpl                                                    */
+  /*   mode "g" : base.mcpl.gz                                                 */
+  /*   mode "b" : base                                                         */
+  /*                                                                           */
+  /*   The returned string must deallocated with a call to free(..).           */
+  MCPL_API char * mcpl_name_helper( const char * filename, char mode );
 
 
 #ifdef __cplusplus

--- a/mcpl_core/src/mcpl.c
+++ b/mcpl_core/src/mcpl.c
@@ -4476,9 +4476,18 @@ mcpl_outfile_t mcpl_create_outfile_mpi( const char * filename,
 {
   if ( nproc > 65535 )
     mcpl_error("mcpl_create_outfile_mpi: nproc too large");
+  if ( nproc == 0 )
+    mcpl_error("mcpl_create_outfile_mpi: nproc must be larger than 0");
   if ( iproc >= nproc )
     mcpl_error("mcpl_create_outfile_mpi: iproc must be less than nproc");
-  mcu8str fn = mcpl_internal_mpiname( filename, iproc, 'm' );
+  mcu8str fn;
+
+  if ( nproc > 1 ) {
+    fn = mcpl_internal_mpiname( filename, iproc, 'm' );
+  } else {
+    //Write directly to target destination:
+    fn = mcpl_internal_mpiname( filename, iproc, 'M' );
+  }
   mcpl_outfile_t outfile = mcpl_create_outfile( fn.c_str );
   mcu8str_dealloc( &fn );
   return outfile;
@@ -4489,6 +4498,12 @@ void mcpl_merge_outfiles_mpi( const char * filename,
 {
   if ( nproc > 65535 )
     mcpl_error("mcpl_merge_outfiles_mpi: nproc too large");
+  if ( nproc == 0 )
+    mcpl_error("mcpl_create_outfile_mpi: nproc must be larger than 0");
+
+  if ( nproc == 1 )
+    return;//nothing to do, we wrote directly to the target.
+
   mcu8str targetfn = mcpl_internal_mpiname( filename, 0, 'M' );
   char ** fns = (char **)mcpl_internal_malloc( sizeof(char*) * nproc);
   for ( unsigned iproc = 0; iproc < nproc; ++iproc ) {

--- a/mcpl_core/src/mcpl.c
+++ b/mcpl_core/src/mcpl.c
@@ -4428,7 +4428,7 @@ MCPL_LOCAL void mcpl_internal_strip_ending( mcu8str* ss,
 }
 
 MCPL_LOCAL mcu8str mcpl_internal_namehelper( const char * filename,
-                                             unsigned iproc,
+                                             unsigned long iproc,
                                              char mode )
 {
   //mode: "m" : /abs/path/base.mpiworker<iproc>.mcpl
@@ -4455,7 +4455,7 @@ MCPL_LOCAL mcu8str mcpl_internal_namehelper( const char * filename,
     //append ".mpiworker<iproc>"
     mode = ( mode == 'm' ? 'M' : 'G' );
     char ebuf[128];
-    snprintf(ebuf,sizeof(ebuf),".mpiworker%u",iproc);
+    snprintf(ebuf,sizeof(ebuf),".mpiworker%lu",iproc);
     mcu8str_append_cstr( &fn, ebuf );
   }
 
@@ -4471,10 +4471,10 @@ MCPL_LOCAL mcu8str mcpl_internal_namehelper( const char * filename,
 }
 
 mcpl_outfile_t mcpl_create_outfile_mpi( const char * filename,
-                                        unsigned iproc,
-                                        unsigned nproc )
+                                        unsigned long iproc,
+                                        unsigned long nproc )
 {
-  if ( nproc > 65535 )
+  if ( nproc > 100000000 )
     mcpl_error("mcpl_create_outfile_mpi: nproc too large");
   if ( nproc == 0 )
     mcpl_error("mcpl_create_outfile_mpi: nproc must be larger than 0");
@@ -4494,7 +4494,7 @@ mcpl_outfile_t mcpl_create_outfile_mpi( const char * filename,
 }
 
 void mcpl_merge_outfiles_mpi( const char * filename,
-                              unsigned nproc )
+                              unsigned long nproc )
 {
   if ( nproc > 65535 )
     mcpl_error("mcpl_merge_outfiles_mpi: nproc too large");
@@ -4506,7 +4506,7 @@ void mcpl_merge_outfiles_mpi( const char * filename,
 
   mcu8str targetfn = mcpl_internal_namehelper( filename, 0, 'M' );
   char ** fns = (char **)mcpl_internal_malloc( sizeof(char*) * nproc);
-  for ( unsigned iproc = 0; iproc < nproc; ++iproc ) {
+  for ( unsigned long iproc = 0; iproc < nproc; ++iproc ) {
     mcu8str fn_i = mcpl_internal_namehelper( filename, iproc, 'g' );
     fns[iproc] = fn_i.c_str;
   }
@@ -4515,7 +4515,7 @@ void mcpl_merge_outfiles_mpi( const char * filename,
   if ( !mcpl_closeandgzip_outfile(outfh) )
     mcpl_error("mcpl_merge_outfiles_mpi: problems gzipping final output");
   //Remove worker files:
-  for ( unsigned iproc = 0; iproc < nproc; ++iproc ) {
+  for ( unsigned long iproc = 0; iproc < nproc; ++iproc ) {
     char * bn = mcpl_basename(fns[iproc]);
     size_t n = 128 + strlen(bn);
     char * buf = mcpl_internal_malloc(n);
@@ -4527,7 +4527,7 @@ void mcpl_merge_outfiles_mpi( const char * filename,
   }
   //Cleanup memory:
   mcu8str_dealloc( &targetfn );
-  for ( unsigned iproc = 0; iproc < nproc; ++iproc )
+  for ( unsigned long iproc = 0; iproc < nproc; ++iproc )
     free( fns[iproc] );
   free(fns);
 }

--- a/tests/src/app_writempi/main.c
+++ b/tests/src/app_writempi/main.c
@@ -1,0 +1,91 @@
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  This file is part of MCPL (see https://mctools.github.io/mcpl/)           //
+//                                                                            //
+//  Copyright 2015-2025 MCPL developers.                                      //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//      http://www.apache.org/licenses/LICENSE-2.0                            //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+#include "mcpl.h"
+#include <stdio.h>
+#include <memory.h>
+
+int main(int argc,char**argv) {
+  (void)argc;
+  (void)argv;
+
+  //Pretend MPI (but actually run in one process:
+
+#define MCPLTEST_NPROC 4
+  const unsigned nproc = MCPLTEST_NPROC;
+
+  //mpi: init files:
+  //init all mpi procs:
+  mcpl_outfile_t outhandles[MCPLTEST_NPROC];
+  for ( unsigned iproc = 0; iproc < nproc; ++iproc ) {
+
+    //It makes no difference if the filename argument is "foobar", "foobar.mcpl"
+    //or "foobar.mcpl.gz". Unit test this:
+    const char * userfn;
+    if ( iproc % 3 == 0 )
+      userfn = "foobar";
+    else if ( iproc % 3 == 1 )
+      userfn = "foobar.mcpl";
+    else
+      userfn = "foobar.mcpl.gz";
+
+    mcpl_outfile_t f = mcpl_create_outfile_mpi( userfn, iproc, nproc );
+    outhandles[iproc] = f;
+    mcpl_hdr_set_srcname(f,"CustomMPITest");
+    mcpl_enable_universal_pdgcode(f,2112);
+    mcpl_hdr_add_comment(f,"Some comment.");
+    mcpl_hdr_add_comment(f,"Another comment.");
+    mcpl_hdr_add_stat_sum(f,"foostat", -1.0 );
+  }
+
+  //mpi: add particles:
+  for ( unsigned iproc = 0; iproc < nproc; ++iproc ) {
+    mcpl_outfile_t f = outhandles[iproc];
+    mcpl_particle_t * particle = mcpl_get_empty_particle(f);
+    for (int i = 0; i < 2; ++i) {
+      particle->position[0] = i*1.0;
+      particle->position[1] = i*2.0;
+      particle->position[2] = i*3.0;
+      particle->ekin = i*0.1;
+      particle->direction[0] = 0.0;
+      particle->direction[1] = 0.0;
+      particle->direction[2] = 1.0;
+      particle->time = i*0.01;
+      particle->weight = (double)iproc;
+      mcpl_add_particle(f,particle);
+    }
+  }
+
+  //mpi: close files
+  for ( unsigned iproc = 0; iproc < nproc; ++iproc ) {
+    mcpl_outfile_t f = outhandles[iproc];
+    mcpl_hdr_add_stat_sum(f,"foostat", 10.0 + iproc );
+    mcpl_closeandgzip_outfile(f);
+  }
+
+  //Merge:
+  mcpl_merge_outfiles_mpi( "foobar", nproc );
+
+  //Dump:
+  mcpl_dump("foobar.mcpl.gz", 0, 0, 0);
+
+  return 0;
+}

--- a/tests/src/app_writempi/main.c
+++ b/tests/src/app_writempi/main.c
@@ -20,8 +20,22 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "mcpl.h"
+#include <stdlib.h>
 #include <stdio.h>
 #include <memory.h>
+#include <string.h>
+
+void mcpltest_name_helper( const char * fn, char mode, const char * expected)
+{
+  static int i = 0;
+  i += 1;
+  char * res = mcpl_name_helper( fn, mode );
+  if ( strcmp( res, expected ) != 0 ) {
+    printf("mcpltest_name_helper test failure (test %i)\n",i);
+    exit(1);
+  }
+  free(res);
+}
 
 int main(int argc,char**argv) {
   (void)argc;
@@ -87,5 +101,18 @@ int main(int argc,char**argv) {
   //Dump:
   mcpl_dump("foobar.mcpl.gz", 0, 0, 0);
 
+  mcpltest_name_helper( "bla", 'm', "bla.mcpl" );
+  mcpltest_name_helper( "bla", 'g', "bla.mcpl.gz" );
+  mcpltest_name_helper( "bla", 'b', "bla" );
+  mcpltest_name_helper( "bla.mcpl", 'm', "bla.mcpl" );
+  mcpltest_name_helper( "bla.mcpl", 'g', "bla.mcpl.gz" );
+  mcpltest_name_helper( "bla.mcpl", 'b', "bla" );
+  mcpltest_name_helper( "bla.mcpl.gz", 'm', "bla.mcpl" );
+  mcpltest_name_helper( "bla.mcpl.gz", 'g', "bla.mcpl.gz" );
+  mcpltest_name_helper( "bla.mcpl.gz", 'b', "bla" );
+
+  char * absfn = mcpl_name_helper( "foobar", 'G' );
+  mcpl_dump(absfn, 0, 0, 0);
+  free(absfn);
   return 0;
 }

--- a/tests/src/app_writempi/main.c
+++ b/tests/src/app_writempi/main.c
@@ -44,12 +44,12 @@ int main(int argc,char**argv) {
   //Pretend MPI (but actually run in one process:
 
 #define MCPLTEST_NPROC 4
-  const unsigned nproc = MCPLTEST_NPROC;
+  const unsigned long nproc = MCPLTEST_NPROC;
 
   //mpi: init files:
   //init all mpi procs:
   mcpl_outfile_t outhandles[MCPLTEST_NPROC];
-  for ( unsigned iproc = 0; iproc < nproc; ++iproc ) {
+  for ( unsigned long iproc = 0; iproc < nproc; ++iproc ) {
 
     //It makes no difference if the filename argument is "foobar", "foobar.mcpl"
     //or "foobar.mcpl.gz". Unit test this:
@@ -71,7 +71,7 @@ int main(int argc,char**argv) {
   }
 
   //mpi: add particles:
-  for ( unsigned iproc = 0; iproc < nproc; ++iproc ) {
+  for ( unsigned long iproc = 0; iproc < nproc; ++iproc ) {
     mcpl_outfile_t f = outhandles[iproc];
     mcpl_particle_t * particle = mcpl_get_empty_particle(f);
     for (int i = 0; i < 2; ++i) {
@@ -89,7 +89,7 @@ int main(int argc,char**argv) {
   }
 
   //mpi: close files
-  for ( unsigned iproc = 0; iproc < nproc; ++iproc ) {
+  for ( unsigned long iproc = 0; iproc < nproc; ++iproc ) {
     mcpl_outfile_t f = outhandles[iproc];
     mcpl_hdr_add_stat_sum(f,"foostat", 10.0 + iproc );
     mcpl_closeandgzip_outfile(f);

--- a/tests/src/app_writempi/test.log
+++ b/tests/src/app_writempi/test.log
@@ -46,3 +46,37 @@ index     pdgcode   ekin[MeV]       x[cm]       y[cm]       z[cm]          ux   
     5        2112         0.1           1           2           3           0           0           1        0.01           2
     6        2112           0           0           0           0           0           0           1           0           3
     7        2112         0.1           1           2           3           0           0           1        0.01           3
+Opened MCPL file foobar.mcpl.gz:
+
+  Basic info
+    Format             : MCPL-3
+    No. of particles   : 8
+    Header storage     : 147 bytes
+    Data storage       : 256 bytes
+
+  Custom meta data
+    Source             : "CustomMPITest"
+    Number of comments : 3
+          -> comment 0 : "Some comment."
+          -> comment 1 : "Another comment."
+          -> comment 2 : "stat:sum:foostat:                      46"
+    Number of blobs    : 0
+
+  Particle data format
+    User flags         : no
+    Polarisation info  : no
+    Fixed part. type   : yes (pdgcode 2112)
+    Fixed part. weight : no
+    FP precision       : single
+    Endianness         : little
+    Storage            : 32 bytes/particle
+
+index     pdgcode   ekin[MeV]       x[cm]       y[cm]       z[cm]          ux          uy          uz    time[ms]      weight
+    0        2112           0           0           0           0           0           0           1           0           0
+    1        2112         0.1           1           2           3           0           0           1        0.01           0
+    2        2112           0           0           0           0           0           0           1           0           1
+    3        2112         0.1           1           2           3           0           0           1        0.01           1
+    4        2112           0           0           0           0           0           0           1           0           2
+    5        2112         0.1           1           2           3           0           0           1        0.01           2
+    6        2112           0           0           0           0           0           0           1           0           3
+    7        2112         0.1           1           2           3           0           0           1        0.01           3

--- a/tests/src/app_writempi/test.log
+++ b/tests/src/app_writempi/test.log
@@ -1,0 +1,48 @@
+MCPL: Compressing file foobar.mpiworker0.mcpl
+MCPL: Compressed file into foobar.mpiworker0.mcpl.gz
+MCPL: Compressing file foobar.mpiworker1.mcpl
+MCPL: Compressed file into foobar.mpiworker1.mcpl.gz
+MCPL: Compressing file foobar.mpiworker2.mcpl
+MCPL: Compressed file into foobar.mpiworker2.mcpl.gz
+MCPL: Compressing file foobar.mpiworker3.mcpl
+MCPL: Compressed file into foobar.mpiworker3.mcpl.gz
+MCPL: Compressing file foobar.mcpl
+MCPL: Compressed file into foobar.mcpl.gz
+MCPL: Removing file foobar.mpiworker0.mcpl.gz
+MCPL: Removing file foobar.mpiworker1.mcpl.gz
+MCPL: Removing file foobar.mpiworker2.mcpl.gz
+MCPL: Removing file foobar.mpiworker3.mcpl.gz
+Opened MCPL file foobar.mcpl.gz:
+
+  Basic info
+    Format             : MCPL-3
+    No. of particles   : 8
+    Header storage     : 147 bytes
+    Data storage       : 256 bytes
+
+  Custom meta data
+    Source             : "CustomMPITest"
+    Number of comments : 3
+          -> comment 0 : "Some comment."
+          -> comment 1 : "Another comment."
+          -> comment 2 : "stat:sum:foostat:                      46"
+    Number of blobs    : 0
+
+  Particle data format
+    User flags         : no
+    Polarisation info  : no
+    Fixed part. type   : yes (pdgcode 2112)
+    Fixed part. weight : no
+    FP precision       : single
+    Endianness         : little
+    Storage            : 32 bytes/particle
+
+index     pdgcode   ekin[MeV]       x[cm]       y[cm]       z[cm]          ux          uy          uz    time[ms]      weight
+    0        2112           0           0           0           0           0           0           1           0           0
+    1        2112         0.1           1           2           3           0           0           1        0.01           0
+    2        2112           0           0           0           0           0           0           1           0           1
+    3        2112         0.1           1           2           3           0           0           1        0.01           1
+    4        2112           0           0           0           0           0           0           1           0           2
+    5        2112         0.1           1           2           3           0           0           1        0.01           2
+    6        2112           0           0           0           0           0           0           1           0           3
+    7        2112         0.1           1           2           3           0           0           1        0.01           3

--- a/tests/src/app_writempi1/main.c
+++ b/tests/src/app_writempi1/main.c
@@ -1,0 +1,65 @@
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  This file is part of MCPL (see https://mctools.github.io/mcpl/)           //
+//                                                                            //
+//  Copyright 2015-2025 MCPL developers.                                      //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//      http://www.apache.org/licenses/LICENSE-2.0                            //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+#include "mcpl.h"
+#include <stdio.h>
+#include <memory.h>
+
+int main(int argc,char**argv) {
+  (void)argc;
+  (void)argv;
+
+  //Test mpi interface with nproc=1
+
+  mcpl_outfile_t f = mcpl_create_outfile_mpi( "foobar", 0, 1 );
+  mcpl_hdr_set_srcname(f,"CustomMPITest");
+  mcpl_enable_universal_pdgcode(f,2112);
+  mcpl_hdr_add_comment(f,"Some comment.");
+  mcpl_hdr_add_comment(f,"Another comment.");
+  mcpl_hdr_add_stat_sum(f,"foostat", -1.0 );
+
+  //mpi: add particles:
+  mcpl_particle_t * particle = mcpl_get_empty_particle(f);
+  for (int i = 0; i < 2; ++i) {
+    particle->position[0] = i*1.0;
+    particle->position[1] = i*2.0;
+    particle->position[2] = i*3.0;
+    particle->ekin = i*0.1;
+    particle->direction[0] = 0.0;
+    particle->direction[1] = 0.0;
+    particle->direction[2] = 1.0;
+    particle->time = i*0.01;
+    particle->weight = 0.0;
+    mcpl_add_particle(f,particle);
+  }
+
+  //mpi: close files
+  mcpl_hdr_add_stat_sum(f,"foostat", 10.0 );
+  mcpl_closeandgzip_outfile(f);
+
+  //Merge:
+  mcpl_merge_outfiles_mpi( "foobar", 1 );
+
+  //Dump:
+  mcpl_dump("foobar.mcpl.gz", 0, 0, 0);
+
+  return 0;
+}

--- a/tests/src/app_writempi1/test.log
+++ b/tests/src/app_writempi1/test.log
@@ -1,0 +1,30 @@
+MCPL: Compressing file foobar.mcpl
+MCPL: Compressed file into foobar.mcpl.gz
+Opened MCPL file foobar.mcpl.gz:
+
+  Basic info
+    Format             : MCPL-3
+    No. of particles   : 2
+    Header storage     : 147 bytes
+    Data storage       : 64 bytes
+
+  Custom meta data
+    Source             : "CustomMPITest"
+    Number of comments : 3
+          -> comment 0 : "Some comment."
+          -> comment 1 : "Another comment."
+          -> comment 2 : "stat:sum:foostat:                      10"
+    Number of blobs    : 0
+
+  Particle data format
+    User flags         : no
+    Polarisation info  : no
+    Fixed part. type   : yes (pdgcode 2112)
+    Fixed part. weight : no
+    FP precision       : single
+    Endianness         : little
+    Storage            : 32 bytes/particle
+
+index     pdgcode   ekin[MeV]       x[cm]       y[cm]       z[cm]          ux          uy          uz    time[ms]      weight
+    0        2112           0           0           0           0           0           0           1           0           0
+    1        2112         0.1           1           2           3           0           0           1        0.01           0


### PR DESCRIPTION
@willend @g5t this PR adds the utility functions we discussed for streamlining the tedious code in all the MCPL_output McStas and McXtrace components concerning creation of temporary MCPL files from each node and ultimately merging them.

Please review and double-check that you think this is what we need in all the various MCPL output components.